### PR TITLE
Introduce `VeldridTexture` and add texture binding support

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -14,7 +14,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 {
     public abstract class TextureGL : ITexture
     {
-        protected readonly IRenderer Renderer;
+        protected readonly OpenGLRenderer Renderer;
 
         /// <summary>
         /// The texture wrap mode in horizontal direction.
@@ -26,7 +26,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         /// </summary>
         public WrapMode WrapModeT { get; }
 
-        protected TextureGL(IRenderer renderer, WrapMode wrapModeS = WrapMode.None, WrapMode wrapModeT = WrapMode.None)
+        protected TextureGL(OpenGLRenderer renderer, WrapMode wrapModeS = WrapMode.None, WrapMode wrapModeT = WrapMode.None)
         {
             Renderer = renderer;
             WrapModeS = wrapModeS;

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlas.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlas.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Runtime.CompilerServices;
 using osu.Framework.Graphics.Primitives;
-using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Textures;
 using osuTK.Graphics.ES30;
 using SixLabors.ImageSharp.PixelFormats;
@@ -27,7 +26,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
         private static readonly Rgba32 initialisation_colour = default;
 
-        public TextureGLAtlas(IRenderer renderer, int width, int height, bool manualMipmaps, All filteringMode = All.Linear, int padding = 0)
+        public TextureGLAtlas(OpenGLRenderer renderer, int width, int height, bool manualMipmaps, All filteringMode = All.Linear, int padding = 0)
             : base(renderer, width, height, manualMipmaps, filteringMode, initialisationColour: initialisation_colour)
         {
             this.padding = padding;

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -67,7 +67,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         /// <param name="wrapModeS">The texture wrap mode in horizontal direction.</param>
         /// <param name="wrapModeT">The texture wrap mode in vertical direction.</param>
         /// <param name="initialisationColour">The colour to initialise texture levels with (in the case of sub region initial uploads).</param>
-        public TextureGLSingle(IRenderer renderer, int width, int height, bool manualMipmaps = false, All filteringMode = All.Linear, WrapMode wrapModeS = WrapMode.None,
+        public TextureGLSingle(OpenGLRenderer renderer, int width, int height, bool manualMipmaps = false, All filteringMode = All.Linear, WrapMode wrapModeS = WrapMode.None,
                                WrapMode wrapModeT = WrapMode.None, Rgba32 initialisationColour = default)
             : base(renderer, wrapModeS, wrapModeT)
         {

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -182,16 +182,6 @@ namespace osu.Framework.Graphics.Rendering
         bool BindTexture(Texture texture, TextureUnit unit = TextureUnit.Texture0, WrapMode? wrapModeS = null, WrapMode? wrapModeT = null);
 
         /// <summary>
-        /// Binds a texture.
-        /// </summary>
-        /// <param name="textureId">The texture to bind.</param>
-        /// <param name="unit">The unit to bind the texture to.</param>
-        /// <param name="wrapModeS">The texture's horizontal wrap mode.</param>
-        /// <param name="wrapModeT">The texture's vertex wrap mode.</param>
-        /// <returns>Whether <paramref name="textureId"/> was newly-bound.</returns>
-        bool BindTexture(int textureId, TextureUnit unit = TextureUnit.Texture0, WrapMode wrapModeS = WrapMode.None, WrapMode wrapModeT = WrapMode.None);
-
-        /// <summary>
         /// Sets the current blending state.
         /// </summary>
         /// <param name="blendingParameters">The blending parameters.</param>

--- a/osu.Framework/Graphics/Rendering/IRenderer.cs
+++ b/osu.Framework/Graphics/Rendering/IRenderer.cs
@@ -265,18 +265,6 @@ namespace osu.Framework.Graphics.Rendering
         void PopDepthInfo();
 
         /// <summary>
-        /// Binds a framebuffer.
-        /// </summary>
-        /// <param name="frameBuffer">The framebuffer to bind.</param>
-        void BindFrameBuffer(int frameBuffer);
-
-        /// <summary>
-        /// Unbinds a framebuffer, if bound.
-        /// </summary>
-        /// <param name="frameBuffer">The framebuffer to unbind.</param>
-        void UnbindFrameBuffer(int frameBuffer);
-
-        /// <summary>
         /// Binds a shader.
         /// </summary>
         /// <param name="shader">The shader to bind.</param>

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -50,7 +50,7 @@ namespace osu.Framework.Graphics.Textures
         }
 
         public Texture(IRenderer renderer, int width, int height, bool manualMipmaps = false, All filteringMode = All.Linear)
-            : this(new TextureGLSingle(renderer, width, height, manualMipmaps, filteringMode))
+            : this(renderer.CreateTexture(width, height, manualMipmaps, filteringMode))
         {
         }
 

--- a/osu.Framework/Graphics/Textures/TextureAtlas.cs
+++ b/osu.Framework/Graphics/Textures/TextureAtlas.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osuTK.Graphics.ES30;
 using osu.Framework.Graphics.Sprites;
@@ -70,7 +71,7 @@ namespace osu.Framework.Graphics.Textures
 
             // We pass PADDING/2 as opposed to PADDING such that the padded region of each individual texture
             // occupies half of the padded space.
-            AtlasTexture = new TextureGLAtlas(renderer, atlasWidth, atlasHeight, manualMipmaps, filteringMode, PADDING / 2);
+            AtlasTexture = new TextureGLAtlas((OpenGLRenderer)renderer, atlasWidth, atlasHeight, manualMipmaps, filteringMode, PADDING / 2);
 
             RectangleI bounds = new RectangleI(0, 0, WHITE_PIXEL_SIZE, WHITE_PIXEL_SIZE);
             subTextureBounds.Add(bounds);

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -116,7 +116,7 @@ namespace osu.Framework.Graphics.Textures
                 }
             }
 
-            nativeTexture ??= new TextureGLSingle(renderer, upload.Width, upload.Height, manualMipmaps, filteringMode, wrapModeS, wrapModeT);
+            nativeTexture ??= renderer.CreateTexture(upload.Width, upload.Height, manualMipmaps, filteringMode, wrapModeS, wrapModeT);
 
             Texture tex = new Texture(nativeTexture) { ScaleAdjust = ScaleAdjust };
             tex.SetData(upload);

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTexture.cs
@@ -1,0 +1,486 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Development;
+using osu.Framework.Extensions.ImageExtensions;
+using osu.Framework.Graphics.OpenGL.Textures;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Lists;
+using osu.Framework.Platform;
+using osuTK;
+using osuTK.Graphics.ES30;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using Veldrid;
+using PixelFormat = Veldrid.PixelFormat;
+using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
+using Texture = Veldrid.Texture;
+
+namespace osu.Framework.Graphics.Veldrid.Textures
+{
+    internal class VeldridTexture : ITexture
+    {
+        /// <summary>
+        /// Contains all currently-active <see cref="VeldridTexture"/>s.
+        /// </summary>
+        private static readonly LockedWeakList<VeldridTexture> all_textures = new LockedWeakList<VeldridTexture>();
+
+        private readonly Queue<ITextureUpload> uploadQueue = new Queue<ITextureUpload>();
+
+        /// <summary>
+        /// Invoked when a new <see cref="VeldridTexture"/> is created.
+        /// </summary>
+        /// <remarks>
+        /// Invocation from the draw or update thread cannot be assumed.
+        /// </remarks>
+        public static event Action<VeldridTexture> TextureCreated;
+
+        private readonly All filteringMode;
+
+        private readonly Rgba32 initialisationColour;
+
+        /// <summary>
+        /// The total amount of times this <see cref="VeldridTexture"/> was bound.
+        /// </summary>
+        public ulong BindCount { get; protected set; }
+
+        public RectangleI Bounds => new RectangleI(0, 0, Width, Height);
+
+        protected virtual TextureUsage Usages
+        {
+            get
+            {
+                var usages = TextureUsage.Sampled;
+
+                if (!manualMipmaps)
+                    usages |= TextureUsage.GenerateMipmaps;
+
+                return usages;
+            }
+        }
+
+        private readonly VeldridRenderer renderer;
+
+        /// <summary>
+        /// Creates a new <see cref="VeldridTexture"/>.
+        /// </summary>
+        /// <param name="renderer">The renderer.</param>
+        /// <param name="width">The width of the texture.</param>
+        /// <param name="height">The height of the texture.</param>
+        /// <param name="manualMipmaps">Whether manual mipmaps will be uploaded to the texture. If false, the texture will compute mipmaps automatically.</param>
+        /// <param name="filteringMode">The filtering mode.</param>
+        /// <param name="wrapModeS">The texture wrap mode in horizontal direction.</param>
+        /// <param name="wrapModeT">The texture wrap mode in vertical direction.</param>
+        /// <param name="initialisationColour">The colour to initialise texture levels with (in the case of sub region initial uploads).</param>
+        public VeldridTexture(VeldridRenderer renderer, int width, int height, bool manualMipmaps = false, All filteringMode = All.Linear,
+                              WrapMode wrapModeS = WrapMode.None, WrapMode wrapModeT = WrapMode.None, Rgba32 initialisationColour = default)
+        {
+            this.renderer = renderer;
+            this.manualMipmaps = manualMipmaps;
+            this.filteringMode = filteringMode;
+            this.initialisationColour = initialisationColour;
+
+            Width = width;
+            Height = height;
+
+            WrapModeS = wrapModeS;
+            WrapModeT = wrapModeT;
+
+            all_textures.Add(this);
+
+            TextureCreated?.Invoke(this);
+        }
+
+        /// <summary>
+        /// Retrieves all currently-active <see cref="VeldridTexture"/>s.
+        /// </summary>
+        public static VeldridTexture[] GetAllTextures() => all_textures.ToArray();
+
+        #region Disposal
+
+        ~VeldridTexture()
+        {
+            Dispose(false);
+        }
+
+        private bool isDisposed;
+
+        public void Dispose()
+        {
+            if (isDisposed)
+                return;
+
+            isDisposed = true;
+
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected void Dispose(bool isDisposing)
+        {
+            all_textures.Remove(this);
+
+            while (tryGetNextUpload(out var upload))
+                upload.Dispose();
+
+            renderer.ScheduleDisposal(t =>
+            {
+                t.Available = false;
+
+                if (t.texture == null)
+                    return;
+
+                t.memoryLease?.Dispose();
+
+                t.resource?.Dispose();
+                t.resource = null;
+
+                t.sampler?.Dispose();
+                t.sampler = null;
+
+                t.texture?.Dispose();
+                t.texture = null;
+            }, this);
+        }
+
+        #endregion
+
+        #region Memory Tracking
+
+        private List<long> levelMemoryUsage = new List<long>();
+
+        private NativeMemoryTracker.NativeMemoryLease memoryLease;
+
+        private void updateMemoryUsage(int level, long newUsage)
+        {
+            levelMemoryUsage ??= new List<long>();
+
+            while (level >= levelMemoryUsage.Count)
+                levelMemoryUsage.Add(0);
+
+            levelMemoryUsage[level] = newUsage;
+
+            memoryLease?.Dispose();
+            memoryLease = NativeMemoryTracker.AddMemory(this, getMemoryUsage());
+        }
+
+        private long getMemoryUsage()
+        {
+            long usage = 0;
+
+            for (int i = 0; i < levelMemoryUsage.Count; i++)
+                usage += levelMemoryUsage[i];
+
+            return usage;
+        }
+
+        #endregion
+
+        public bool Available { get; private set; }
+        public bool BypassTextureUploadQueueing { get; set; }
+
+        bool ITexture.IsQueuedForUpload { get; set; }
+
+        public Opacity Opacity { get; private set; }
+
+        public int MaxSize => renderer.MaxTextureSize;
+
+        public WrapMode WrapModeS { get; }
+        public WrapMode WrapModeT { get; }
+
+        public int Width { get; set; }
+        public int Height { get; set; }
+
+        private Texture texture;
+        private Sampler sampler;
+
+        private VeldridTextureSamplerSet resource;
+
+        public VeldridTextureSamplerSet Resource
+        {
+            get
+            {
+                if (!Available)
+                    throw new ObjectDisposedException(ToString(), "Can not obtain resource set of a disposed texture.");
+
+                if (resource == null)
+                    throw new InvalidOperationException("Can not obtain resource set of a texture before uploading it.");
+
+                return resource;
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the size of this texture in bytes.
+        /// </summary>
+        public virtual int GetByteSize() => Width * Height * 4;
+
+        private static void rotateVector(ref Vector2 toRotate, float sin, float cos)
+        {
+            float oldX = toRotate.X;
+            toRotate.X = toRotate.X * cos - toRotate.Y * sin;
+            toRotate.Y = oldX * sin + toRotate.Y * cos;
+        }
+
+        public RectangleF GetTextureRect(RectangleF? textureRect)
+        {
+            RectangleF texRect = textureRect != null
+                ? new RectangleF(textureRect.Value.X, textureRect.Value.Y, textureRect.Value.Width, textureRect.Value.Height)
+                : new RectangleF(0, 0, Width, Height);
+
+            texRect.X /= Width;
+            texRect.Y /= Height;
+            texRect.Width /= Width;
+            texRect.Height /= Height;
+
+            return texRect;
+        }
+
+        public const int VERTICES_PER_TRIANGLE = 4;
+
+        public const int VERTICES_PER_QUAD = 4;
+
+        public void SetData(ITextureUpload upload)
+        {
+            throw new NotImplementedException();
+        }
+
+        void ITexture.SetData(ITextureUpload upload, WrapMode wrapModeS, WrapMode wrapModeT, Opacity? uploadOpacity)
+        {
+            SetData(upload, wrapModeS, wrapModeT, uploadOpacity);
+        }
+
+        internal virtual void SetData(ITextureUpload upload, WrapMode wrapModeS, WrapMode wrapModeT, Opacity? uploadOpacity)
+        {
+            if (!Available)
+                throw new ObjectDisposedException(ToString(), "Can not set data of a disposed texture.");
+
+            if (upload.Bounds.IsEmpty && upload.Data.Length > 0)
+            {
+                upload.Bounds = Bounds;
+                if (Width * Height > upload.Data.Length)
+                    throw new InvalidOperationException($"Size of texture upload ({Width}x{Height}) does not contain enough data ({upload.Data.Length} < {Width * Height})");
+            }
+
+            UpdateOpacity(upload, ref uploadOpacity);
+
+            lock (uploadQueue)
+            {
+                // bool requireUpload = uploadQueue.Count == 0;
+                uploadQueue.Enqueue(upload);
+
+                // todo: support enqueuing texture uploads in IRenderer
+                // if (requireUpload && !BypassTextureUploadQueueing)
+                // renderer.EnqueueTextureUpload(this);
+            }
+        }
+
+        protected static Opacity ComputeOpacity(ITextureUpload upload)
+        {
+            // TODO: Investigate performance issues and revert functionality once we are sure there is no overhead.
+            // see https://github.com/ppy/osu/issues/9307
+            return Opacity.Mixed;
+
+            // ReadOnlySpan<Rgba32> data = upload.Data;
+            //
+            // if (data.Length == 0)
+            //     return Opacity.Transparent;
+            //
+            // int firstPixelValue = data[0].A;
+            //
+            // // Check if the first pixel has partial transparency (neither fully-opaque nor fully-transparent).
+            // if (firstPixelValue != 0 && firstPixelValue != 255)
+            //     return Opacity.Mixed;
+            //
+            // // The first pixel is GUARANTEED to be either fully-opaque or fully-transparent.
+            // // Now we need to go through the rest of the image and check that every other pixel matches this value.
+            // for (int i = 1; i < data.Length; i++)
+            // {
+            //     if (data[i].A != firstPixelValue)
+            //         return Opacity.Mixed;
+            // }
+            //
+            // return firstPixelValue == 0 ? Opacity.Transparent : Opacity.Opaque;
+        }
+
+        protected void UpdateOpacity(ITextureUpload upload, ref Opacity? uploadOpacity)
+        {
+            // Compute opacity if it doesn't have a value yet
+            uploadOpacity ??= ComputeOpacity(upload);
+
+            // Update the texture's opacity depending on the upload's opacity.
+            // If the upload covers the entire bounds of the texture, it fully
+            // determines the texture's opacity. Otherwise, it can only turn
+            // the texture's opacity into a mixed state (if it disagrees with
+            // the texture's existing opacity).
+            if (upload.Bounds == Bounds && upload.Level == 0)
+                Opacity = uploadOpacity.Value;
+            else if (uploadOpacity.Value != Opacity)
+                Opacity = Opacity.Mixed;
+        }
+
+        /// <summary>
+        /// Whether this <see cref="VeldridTexture"/> generates mipmaps manually.
+        /// </summary>
+        private readonly bool manualMipmaps;
+
+        bool ITexture.Bind(TextureUnit unit, WrapMode wrapModeS, WrapMode wrapModeT)
+        {
+            if (!Available)
+                throw new ObjectDisposedException(ToString(), "Can not bind a disposed texture.");
+
+            Upload();
+
+            if (resource == null)
+                return false;
+
+            if (renderer.BindTexture(resource, wrapModeS, wrapModeT))
+                BindCount++;
+
+            return true;
+        }
+
+        internal bool Upload()
+        {
+            if (!Available)
+                return false;
+
+            // We should never run raw Veldrid calls on another thread than the draw thread due to race conditions.
+            ThreadSafety.EnsureDrawThread();
+
+            bool didUpload = false;
+
+            while (tryGetNextUpload(out ITextureUpload upload))
+            {
+                using (upload)
+                {
+                    DoUpload(upload);
+                    didUpload = true;
+                }
+            }
+
+            if (didUpload && !(manualMipmaps || maximumUploadedLod > 0))
+                renderer.Commands.GenerateMipmaps(texture);
+
+            return didUpload;
+        }
+
+        bool ITexture.Upload() => Upload();
+
+        private bool tryGetNextUpload(out ITextureUpload upload)
+        {
+            lock (uploadQueue)
+            {
+                if (uploadQueue.Count == 0)
+                {
+                    upload = null;
+                    return false;
+                }
+
+                upload = uploadQueue.Dequeue();
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// The maximum number of mip levels provided by a <see cref="ITextureUpload"/>.
+        /// </summary>
+        /// <remarks>
+        /// This excludes automatic generation of mipmaps via the graphics backend.
+        /// </remarks>
+        private int maximumUploadedLod;
+
+        protected virtual void DoUpload(ITextureUpload upload)
+        {
+            if (texture == null || texture.Width != Width || texture.Height != Height)
+            {
+                resource?.Dispose();
+                resource = null;
+
+                sampler?.Dispose();
+                sampler = null;
+
+                texture?.Dispose();
+
+                var textureDescription = TextureDescription.Texture2D((uint)Width, (uint)Height, (uint)calculateMipmapLevels(Width, Height), 1, PixelFormat.R8_G8_B8_A8_UNorm_SRgb, Usages);
+                texture = renderer.Factory.CreateTexture(textureDescription);
+
+                // todo: we should probably look into not having to allocate enough data for initialising textures
+                // similar to how OpenGL allows calling glTexImage2D with null data pointer.
+                initialiseLevel(0, Width, Height);
+
+                maximumUploadedLod = 0;
+            }
+
+            int lastMaximumUploadedLod = maximumUploadedLod;
+
+            if (!upload.Data.IsEmpty)
+            {
+                // ensure all mip levels up to the target level are initialised.
+                if (upload.Level > maximumUploadedLod)
+                {
+                    for (int i = maximumUploadedLod + 1; i <= upload.Level; i++)
+                        initialiseLevel(i, Width >> i, Height >> i);
+
+                    maximumUploadedLod = upload.Level;
+                }
+
+                renderer.UpdateTexture(texture, upload.Bounds.X >> upload.Level, upload.Bounds.Y >> upload.Level, upload.Bounds.Width >> upload.Level, upload.Bounds.Height >> upload.Level, upload.Level, upload.Data);
+            }
+
+            if (sampler == null || maximumUploadedLod > lastMaximumUploadedLod)
+            {
+                resource?.Dispose();
+                resource = null;
+
+                sampler?.Dispose();
+
+                bool useUploadMipmaps = manualMipmaps || maximumUploadedLod > 0;
+
+                var samplerDescription = new SamplerDescription
+                {
+                    AddressModeU = SamplerAddressMode.Clamp,
+                    AddressModeV = SamplerAddressMode.Clamp,
+                    AddressModeW = SamplerAddressMode.Clamp,
+                    Filter = filteringMode.ToSamplerFilter(),
+                    MinimumLod = 0,
+                    MaximumLod = useUploadMipmaps ? (uint)maximumUploadedLod : IRenderer.MAX_MIPMAP_LEVELS,
+                    MaximumAnisotropy = 0,
+                };
+
+                sampler = renderer.Factory.CreateSampler(samplerDescription);
+            }
+
+            resource ??= new VeldridTextureSamplerSet(renderer, texture, sampler);
+        }
+
+        private unsafe void initialiseLevel(int level, int width, int height)
+        {
+            using (var image = createBackingImage(width, height))
+            using (var pixels = image.CreateReadOnlyPixelSpan())
+            {
+                updateMemoryUsage(level, (long)width * height * sizeof(Rgba32));
+                renderer.UpdateTexture(texture, 0, 0, width, height, level, pixels.Span);
+            }
+        }
+
+        private Image<Rgba32> createBackingImage(int width, int height)
+        {
+            // it is faster to initialise without a background specification if transparent black is all that's required.
+            return initialisationColour == default
+                ? new Image<Rgba32>(width, height)
+                : new Image<Rgba32>(width, height, initialisationColour);
+        }
+
+        // todo: should this be limited to MAX_MIPMAP_LEVELS or was that constant supposed to be for automatic mipmap generation only?
+        // previous implementation was allocating mip levels all the way to 1x1 size when an ITextureUpload.Level > 0, therefore it's not limited there.
+        private static int calculateMipmapLevels(int width, int height) => 1 + (int)Math.Floor(Math.Log(Math.Max(width, height), 2));
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTextureAtlas.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTextureAtlas.cs
@@ -1,0 +1,222 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System;
+using System.Runtime.CompilerServices;
+using osu.Framework.Graphics.OpenGL.Textures;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Textures;
+using osuTK.Graphics.ES30;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace osu.Framework.Graphics.Veldrid.Textures
+{
+    /// <summary>
+    /// A <see cref="VeldridTexture"/> which is acting as the backing for an atlas.
+    /// </summary>
+    internal class VeldridTextureAtlas : VeldridTexture
+    {
+        /// <summary>
+        /// The amount of padding around each texture in the atlas.
+        /// </summary>
+        private readonly int padding;
+
+        private readonly RectangleI atlasBounds;
+
+        private static readonly Rgba32 initialisation_colour = default;
+
+        public VeldridTextureAtlas(VeldridRenderer renderer, int width, int height, bool manualMipmaps, All filteringMode = All.Linear, int padding = 0)
+            : base(renderer, width, height, manualMipmaps, filteringMode, initialisationColour: initialisation_colour)
+        {
+            this.padding = padding;
+
+            atlasBounds = new RectangleI(0, 0, Width, Height);
+        }
+
+        internal override void SetData(ITextureUpload upload, WrapMode wrapModeS, WrapMode wrapModeT, Opacity? uploadOpacity)
+        {
+            // Can only perform padding when the bounds are a sub-part of the texture
+            RectangleI middleBounds = upload.Bounds;
+
+            if (middleBounds.IsEmpty || middleBounds.Width * middleBounds.Height > upload.Data.Length)
+            {
+                // For a texture atlas, we don't care about opacity, so we avoid
+                // any computations related to it by assuming it to be mixed.
+                base.SetData(upload, wrapModeS, wrapModeT, Opacity.Mixed);
+                return;
+            }
+
+            int actualPadding = padding / (1 << upload.Level);
+
+            var data = upload.Data;
+
+            uploadCornerPadding(data, middleBounds, actualPadding, wrapModeS != WrapMode.None && wrapModeT != WrapMode.None);
+            uploadHorizontalPadding(data, middleBounds, actualPadding, wrapModeS != WrapMode.None);
+            uploadVerticalPadding(data, middleBounds, actualPadding, wrapModeT != WrapMode.None);
+
+            // Upload the middle part of the texture
+            // For a texture atlas, we don't care about opacity, so we avoid
+            // any computations related to it by assuming it to be mixed.
+            base.SetData(upload, wrapModeS, wrapModeT, Opacity.Mixed);
+        }
+
+        private void uploadVerticalPadding(ReadOnlySpan<Rgba32> upload, RectangleI middleBounds, int actualPadding, bool fillOpaque)
+        {
+            RectangleI[] sideBoundsArray =
+            {
+                new RectangleI(middleBounds.X, middleBounds.Y - actualPadding, middleBounds.Width, actualPadding).Intersect(atlasBounds), // Top
+                new RectangleI(middleBounds.X, middleBounds.Y + middleBounds.Height, middleBounds.Width, actualPadding).Intersect(atlasBounds), // Bottom
+            };
+
+            int[] sideIndices =
+            {
+                0, // Top
+                (middleBounds.Height - 1) * middleBounds.Width, // Bottom
+            };
+
+            for (int i = 0; i < 2; ++i)
+            {
+                RectangleI sideBounds = sideBoundsArray[i];
+
+                if (!sideBounds.IsEmpty)
+                {
+                    bool allTransparent = true;
+                    int index = sideIndices[i];
+
+                    var sideUpload = new MemoryAllocatorTextureUpload(sideBounds.Width, sideBounds.Height) { Bounds = sideBounds };
+                    var data = sideUpload.RawData;
+
+                    for (int y = 0; y < sideBounds.Height; ++y)
+                    {
+                        for (int x = 0; x < sideBounds.Width; ++x)
+                        {
+                            Rgba32 pixel = upload[index + x];
+                            allTransparent &= checkEdgeRGB(pixel);
+
+                            transferBorderPixel(ref data[y * sideBounds.Width + x], pixel, fillOpaque);
+                        }
+                    }
+
+                    // Only upload padding if the border isn't completely transparent.
+                    if (!allTransparent)
+                    {
+                        // For a texture atlas, we don't care about opacity, so we avoid
+                        // any computations related to it by assuming it to be mixed.
+                        base.SetData(sideUpload, WrapMode.None, WrapMode.None, Opacity.Mixed);
+                    }
+                }
+            }
+        }
+
+        private void uploadHorizontalPadding(ReadOnlySpan<Rgba32> upload, RectangleI middleBounds, int actualPadding, bool fillOpaque)
+        {
+            RectangleI[] sideBoundsArray =
+            {
+                new RectangleI(middleBounds.X - actualPadding, middleBounds.Y, actualPadding, middleBounds.Height).Intersect(atlasBounds), // Left
+                new RectangleI(middleBounds.X + middleBounds.Width, middleBounds.Y, actualPadding, middleBounds.Height).Intersect(atlasBounds), // Right
+            };
+
+            int[] sideIndices =
+            {
+                0, // Left
+                middleBounds.Width - 1, // Right
+            };
+
+            for (int i = 0; i < 2; ++i)
+            {
+                RectangleI sideBounds = sideBoundsArray[i];
+
+                if (!sideBounds.IsEmpty)
+                {
+                    bool allTransparent = true;
+                    int index = sideIndices[i];
+
+                    var sideUpload = new MemoryAllocatorTextureUpload(sideBounds.Width, sideBounds.Height) { Bounds = sideBounds };
+                    var data = sideUpload.RawData;
+
+                    int stride = middleBounds.Width;
+
+                    for (int y = 0; y < sideBounds.Height; ++y)
+                    {
+                        for (int x = 0; x < sideBounds.Width; ++x)
+                        {
+                            Rgba32 pixel = upload[index + y * stride];
+
+                            allTransparent &= checkEdgeRGB(pixel);
+
+                            transferBorderPixel(ref data[y * sideBounds.Width + x], pixel, fillOpaque);
+                        }
+                    }
+
+                    // Only upload padding if the border isn't completely transparent.
+                    if (!allTransparent)
+                    {
+                        // For a texture atlas, we don't care about opacity, so we avoid
+                        // any computations related to it by assuming it to be mixed.
+                        base.SetData(sideUpload, WrapMode.None, WrapMode.None, Opacity.Mixed);
+                    }
+                }
+            }
+        }
+
+        private void uploadCornerPadding(ReadOnlySpan<Rgba32> upload, RectangleI middleBounds, int actualPadding, bool fillOpaque)
+        {
+            RectangleI[] cornerBoundsArray =
+            {
+                new RectangleI(middleBounds.X - actualPadding, middleBounds.Y - actualPadding, actualPadding, actualPadding).Intersect(atlasBounds), // TopLeft
+                new RectangleI(middleBounds.X + middleBounds.Width, middleBounds.Y - actualPadding, actualPadding, actualPadding).Intersect(atlasBounds), // TopRight
+                new RectangleI(middleBounds.X - actualPadding, middleBounds.Y + middleBounds.Height, actualPadding, actualPadding).Intersect(atlasBounds), // BottomLeft
+                new RectangleI(middleBounds.X + middleBounds.Width, middleBounds.Y + middleBounds.Height, actualPadding, actualPadding).Intersect(atlasBounds), // BottomRight
+            };
+
+            int[] cornerIndices =
+            {
+                0, // TopLeft
+                middleBounds.Width - 1, // TopRight
+                (middleBounds.Height - 1) * middleBounds.Width, // BottomLeft
+                (middleBounds.Height - 1) * middleBounds.Width + middleBounds.Width - 1, // BottomRight
+            };
+
+            for (int i = 0; i < 4; ++i)
+            {
+                RectangleI cornerBounds = cornerBoundsArray[i];
+                int nCornerPixels = cornerBounds.Width * cornerBounds.Height;
+                Rgba32 pixel = upload[cornerIndices[i]];
+
+                // Only upload if we have a non-zero size and if the colour isn't already transparent white
+                if (nCornerPixels > 0 && !checkEdgeRGB(pixel))
+                {
+                    var cornerUpload = new MemoryAllocatorTextureUpload(cornerBounds.Width, cornerBounds.Height) { Bounds = cornerBounds };
+                    var data = cornerUpload.RawData;
+
+                    for (int j = 0; j < nCornerPixels; ++j)
+                        transferBorderPixel(ref data[j], pixel, fillOpaque);
+
+                    // For a texture atlas, we don't care about opacity, so we avoid
+                    // any computations related to it by assuming it to be mixed.
+                    base.SetData(cornerUpload, WrapMode.None, WrapMode.None, Opacity.Mixed);
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void transferBorderPixel(ref Rgba32 dest, Rgba32 source, bool fillOpaque)
+        {
+            dest.R = source.R;
+            dest.G = source.G;
+            dest.B = source.B;
+            dest.A = fillOpaque ? source.A : (byte)0;
+        }
+
+        /// <summary>
+        /// Check whether the provided upload edge pixel's RGB components match the initialisation colour.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool checkEdgeRGB(Rgba32 cornerPixel)
+            => cornerPixel.R == initialisation_colour.R
+               && cornerPixel.G == initialisation_colour.G
+               && cornerPixel.B == initialisation_colour.B;
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/Textures/VeldridTextureSamplerSet.cs
+++ b/osu.Framework/Graphics/Veldrid/Textures/VeldridTextureSamplerSet.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Veldrid;
+
+namespace osu.Framework.Graphics.Veldrid.Textures
+{
+    /// <summary>
+    /// Represents a texture-sampler resource usable by <see cref="VeldridRenderer"/> to bind textures, acting similar to an OpenGL texture ID.
+    /// </summary>
+    public class VeldridTextureSamplerSet : IDisposable
+    {
+        public IReadOnlyList<Texture> Textures { get; }
+        public Texture Texture => Textures.Single();
+
+        public Sampler Sampler { get; }
+
+        public ResourceLayout Layout { get; }
+
+        private readonly ResourceSet resourceSet;
+
+        public VeldridTextureSamplerSet(VeldridRenderer renderer, Texture texture, Sampler sampler)
+            : this(renderer, new[] { texture }, sampler)
+        {
+        }
+
+        public VeldridTextureSamplerSet(VeldridRenderer renderer, Texture[] textures, Sampler sampler)
+        {
+            Textures = textures;
+            Sampler = sampler;
+
+            Layout = renderer.GetTextureResourceLayout(textures.Length);
+
+            resourceSet = renderer.Factory.CreateResourceSet(new ResourceSetDescription(Layout, textures.Append<BindableResource>(sampler).ToArray()));
+        }
+
+        public void Dispose()
+        {
+            resourceSet?.Dispose();
+        }
+
+        public static implicit operator ResourceSet(VeldridTextureSamplerSet veldridTextureSet) => veldridTextureSet.resourceSet;
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/VeldridExtensions.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridExtensions.cs
@@ -1,0 +1,140 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osuTK.Graphics;
+using osuTK.Graphics.ES30;
+using Veldrid;
+
+namespace osu.Framework.Graphics.Veldrid
+{
+    public static class VeldridExtensions
+    {
+        public static RgbaFloat ToRgbaFloat(this Color4 colour) => new RgbaFloat(colour.R, colour.G, colour.B, colour.A);
+
+        // todo: ColorWriteMask is necessary for front-to-back render support.
+        // public static BlendAttachmentDescription ToBlendAttachment(this BlendingParameters parameters, ColorWriteMask writeMask = ColorWriteMask.All) => new BlendAttachmentDescription
+        public static BlendAttachmentDescription ToBlendAttachment(this BlendingParameters parameters) => new BlendAttachmentDescription
+        {
+            BlendEnabled = !parameters.IsDisabled,
+            SourceColorFactor = parameters.Source.ToBlendFactor(),
+            SourceAlphaFactor = parameters.SourceAlpha.ToBlendFactor(),
+            DestinationColorFactor = parameters.Destination.ToBlendFactor(),
+            DestinationAlphaFactor = parameters.DestinationAlpha.ToBlendFactor(),
+            ColorFunction = parameters.RGBEquation.ToBlendFunction(),
+            AlphaFunction = parameters.AlphaEquation.ToBlendFunction(),
+            // ColorWriteMask = writeMask,
+        };
+
+        public static BlendFactor ToBlendFactor(this BlendingType type)
+        {
+            switch (type)
+            {
+                case BlendingType.DstAlpha:
+                    return BlendFactor.DestinationAlpha;
+
+                case BlendingType.DstColor:
+                    return BlendFactor.DestinationColor;
+
+                case BlendingType.SrcAlpha:
+                    return BlendFactor.SourceAlpha;
+
+                case BlendingType.SrcColor:
+                    return BlendFactor.SourceColor;
+
+                case BlendingType.OneMinusDstAlpha:
+                    return BlendFactor.InverseDestinationAlpha;
+
+                case BlendingType.OneMinusDstColor:
+                    return BlendFactor.InverseDestinationColor;
+
+                case BlendingType.OneMinusSrcAlpha:
+                    return BlendFactor.InverseSourceAlpha;
+
+                case BlendingType.OneMinusSrcColor:
+                    return BlendFactor.InverseSourceColor;
+
+                case BlendingType.One:
+                    return BlendFactor.One;
+
+                case BlendingType.Zero:
+                    return BlendFactor.Zero;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type));
+            }
+        }
+
+        public static BlendFunction ToBlendFunction(this BlendingEquation equation)
+        {
+            switch (equation)
+            {
+                case BlendingEquation.Add:
+                    return BlendFunction.Add;
+
+                case BlendingEquation.Subtract:
+                    return BlendFunction.Subtract;
+
+                case BlendingEquation.ReverseSubtract:
+                    return BlendFunction.ReverseSubtract;
+
+                case BlendingEquation.Min:
+                    return BlendFunction.Minimum;
+
+                case BlendingEquation.Max:
+                    return BlendFunction.Maximum;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(equation));
+            }
+        }
+
+        public static SamplerFilter ToSamplerFilter(this All mode)
+        {
+            switch (mode)
+            {
+                case All.Linear:
+                    return SamplerFilter.MinLinear_MagLinear_MipLinear;
+
+                case All.Nearest:
+                    return SamplerFilter.MinPoint_MagPoint_MipPoint;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(mode));
+            }
+        }
+
+        public static ComparisonKind ToComparisonKind(this DepthFunction function)
+        {
+            switch (function)
+            {
+                case DepthFunction.Always:
+                    return ComparisonKind.Always;
+
+                case DepthFunction.Never:
+                    return ComparisonKind.Never;
+
+                case DepthFunction.Less:
+                    return ComparisonKind.Less;
+
+                case DepthFunction.Equal:
+                    return ComparisonKind.Equal;
+
+                case DepthFunction.Lequal:
+                    return ComparisonKind.LessEqual;
+
+                case DepthFunction.Greater:
+                    return ComparisonKind.Greater;
+
+                case DepthFunction.Notequal:
+                    return ComparisonKind.NotEqual;
+
+                case DepthFunction.Gequal:
+                    return ComparisonKind.GreaterEqual;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(function));
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -197,7 +197,6 @@ namespace osu.Framework.Graphics.Veldrid
             currentShader?.Unbind();
             currentShader = null;
             shaderStack.Clear();
-            GL.UseProgram(0);
 
             viewportStack.Clear();
             orthoStack.Clear();
@@ -755,7 +754,12 @@ namespace osu.Framework.Graphics.Veldrid
 
             flushCurrentBatch();
 
-            GL.UseProgram(shader);
+            // todo: support Veldrid shaders once IRenderer supports creating its own shaders
+            // pipelineDescription.ShaderSet.Shaders = shader.Shaders;
+
+            // if (shader.VertexLayout.Elements?.Length > 0)
+                // pipelineDescription.ShaderSet.VertexLayouts = new[] { shader.VertexLayout };
+
             currentShader = shader;
         }
 
@@ -787,44 +791,45 @@ namespace osu.Framework.Graphics.Veldrid
             if (uniform.Owner == currentShader)
                 flushCurrentBatch();
 
-            switch (uniform)
-            {
-                case IUniformWithValue<bool> b:
-                    GL.Uniform1(uniform.Location, b.GetValue() ? 1 : 0);
-                    break;
-
-                case IUniformWithValue<int> i:
-                    GL.Uniform1(uniform.Location, i.GetValue());
-                    break;
-
-                case IUniformWithValue<float> f:
-                    GL.Uniform1(uniform.Location, f.GetValue());
-                    break;
-
-                case IUniformWithValue<Vector2> v2:
-                    GL.Uniform2(uniform.Location, ref v2.GetValueByRef());
-                    break;
-
-                case IUniformWithValue<Vector3> v3:
-                    GL.Uniform3(uniform.Location, ref v3.GetValueByRef());
-                    break;
-
-                case IUniformWithValue<Vector4> v4:
-                    GL.Uniform4(uniform.Location, ref v4.GetValueByRef());
-                    break;
-
-                case IUniformWithValue<Matrix2> m2:
-                    GL.UniformMatrix2(uniform.Location, false, ref m2.GetValueByRef());
-                    break;
-
-                case IUniformWithValue<Matrix3> m3:
-                    GL.UniformMatrix3(uniform.Location, false, ref m3.GetValueByRef());
-                    break;
-
-                case IUniformWithValue<Matrix4> m4:
-                    GL.UniformMatrix4(uniform.Location, false, ref m4.GetValueByRef());
-                    break;
-            }
+            // todo: pending veldrid shader support, reference code: https://github.com/frenzibyte/osu-framework/blob/3e9458b007b1de1eaaa5f0483387c862f27bb331/osu.Framework/Graphics/Veldrid/Vd_Resources.cs#L267-L298
+            // switch (uniform)
+            // {
+            //     case IUniformWithValue<bool> b:
+            //         GL.Uniform1(uniform.Location, b.GetValue() ? 1 : 0);
+            //         break;
+            //
+            //     case IUniformWithValue<int> i:
+            //         GL.Uniform1(uniform.Location, i.GetValue());
+            //         break;
+            //
+            //     case IUniformWithValue<float> f:
+            //         GL.Uniform1(uniform.Location, f.GetValue());
+            //         break;
+            //
+            //     case IUniformWithValue<Vector2> v2:
+            //         GL.Uniform2(uniform.Location, ref v2.GetValueByRef());
+            //         break;
+            //
+            //     case IUniformWithValue<Vector3> v3:
+            //         GL.Uniform3(uniform.Location, ref v3.GetValueByRef());
+            //         break;
+            //
+            //     case IUniformWithValue<Vector4> v4:
+            //         GL.Uniform4(uniform.Location, ref v4.GetValueByRef());
+            //         break;
+            //
+            //     case IUniformWithValue<Matrix2> m2:
+            //         GL.UniformMatrix2(uniform.Location, false, ref m2.GetValueByRef());
+            //         break;
+            //
+            //     case IUniformWithValue<Matrix3> m3:
+            //         GL.UniformMatrix3(uniform.Location, false, ref m3.GetValueByRef());
+            //         break;
+            //
+            //     case IUniformWithValue<Matrix4> m4:
+            //         GL.UniformMatrix4(uniform.Location, false, ref m4.GetValueByRef());
+            //         break;
+            // }
         }
 
         void IRenderer.RegisterVertexBufferUse(IVertexBuffer buffer) => vertexBuffersInUse.Add(buffer);

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -96,16 +96,14 @@ namespace osu.Framework.Graphics.Veldrid
         private bool isInitialised;
         private IVertexBatch<TexturedVertex2D>? defaultQuadBatch;
 
+        public GraphicsDevice Device { get; set; }
+
+
         void IRenderer.Initialise()
         {
-            string version = GL.GetString(StringName.Version);
-            IsEmbedded = version.Contains("OpenGL ES"); // As defined by https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glGetString.xml
-
-            MaxTextureSize = GL.GetInteger(GetPName.MaxTextureSize);
-            MaxRenderBufferSize = GL.GetInteger(GetPName.MaxRenderbufferSize);
-
-            GL.Disable(EnableCap.StencilTest);
-            GL.Enable(EnableCap.Blend);
+            // todo: port device creation logic (https://github.com/frenzibyte/osu-framework/blob/3e9458b007b1de1eaaa5f0483387c862f27bb331/osu.Framework/Graphics/Veldrid/Vd_Device.cs#L21-L240)
+            // that requires further thought as it includes acquiring the current window and display handle.
+            Device = null!;
 
             defaultQuadBatch = CreateQuadBatch<TexturedVertex2D>(100, 1000);
 

--- a/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
+++ b/osu.Framework/Graphics/Veldrid/VeldridRenderer.cs
@@ -1,0 +1,848 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using osu.Framework.Development;
+using osu.Framework.Graphics.Batches;
+using osu.Framework.Graphics.OpenGL;
+using osu.Framework.Graphics.OpenGL.Buffers;
+using osu.Framework.Graphics.OpenGL.Textures;
+using osu.Framework.Graphics.OpenGL.Vertices;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Rendering;
+using osu.Framework.Graphics.Shaders;
+using osu.Framework.Platform;
+using osu.Framework.Statistics;
+using osu.Framework.Threading;
+using osu.Framework.Timing;
+using osuTK;
+using osuTK.Graphics;
+using osuTK.Graphics.ES30;
+using SDL2;
+using Veldrid;
+using PixelFormat = Veldrid.PixelFormat;
+using Shader = osu.Framework.Graphics.Shaders.Shader;
+using Texture = osu.Framework.Graphics.Textures.Texture;
+
+namespace osu.Framework.Graphics.Veldrid
+{
+    public class VeldridRenderer : IRenderer
+    {
+        /// <summary>
+        /// The interval (in frames) before checking whether VBOs should be freed.
+        /// VBOs may remain unused for at most double this length before they are recycled.
+        /// </summary>
+        private const int vbo_free_check_interval = 300;
+
+        public int MaxTextureSize { get; private set; } = 4096; // default value is to allow roughly normal flow in cases we don't have a graphics context, like headless CI.
+        public int MaxRenderBufferSize { get; private set; } = 4096; // default value is to allow roughly normal flow in cases we don't have a graphics context, like headless CI.
+        public int MaxTexturesUploadedPerFrame { get; set; } = 32;
+        public int MaxPixelsUploadedPerFrame { get; set; } = 1024 * 1024 * 2;
+        public bool IsEmbedded { get; private set; }
+        public ulong ResetId { get; private set; }
+        public ref readonly MaskingInfo CurrentMaskingInfo => ref currentMaskingInfo;
+        public RectangleI Viewport { get; private set; }
+        public RectangleF Ortho { get; private set; }
+        public RectangleI Scissor { get; private set; }
+        public Vector2I ScissorOffset { get; private set; }
+        public Matrix4 ProjectionMatrix { get; private set; }
+        public DepthInfo CurrentDepthInfo { get; private set; }
+        public WrapMode CurrentWrapModeS { get; private set; }
+        public WrapMode CurrentWrapModeT { get; private set; }
+        public bool IsMaskingActive => maskingStack.Count > 1;
+        public float BackbufferDrawDepth { get; private set; }
+        public bool UsingBackbuffer => frameBufferStack.Count > 0 && frameBufferStack.Peek() == BackbufferFramebuffer;
+
+        protected virtual int BackbufferFramebuffer => 0;
+
+        private readonly GlobalStatistic<int> statExpensiveOperationsQueued = GlobalStatistics.Get<int>(nameof(VeldridRenderer), "Expensive operation queue length");
+        private readonly GlobalStatistic<int> statTextureUploadsQueued = GlobalStatistics.Get<int>(nameof(VeldridRenderer), "Texture upload queue length");
+        private readonly GlobalStatistic<int> statTextureUploadsDequeued = GlobalStatistics.Get<int>(nameof(VeldridRenderer), "Texture uploads dequeued");
+        private readonly GlobalStatistic<int> statTextureUploadsPerformed = GlobalStatistics.Get<int>(nameof(VeldridRenderer), "Texture uploads performed");
+
+        private readonly ConcurrentQueue<ScheduledDelegate> expensiveOperationQueue = new ConcurrentQueue<ScheduledDelegate>();
+        private readonly ConcurrentQueue<TextureGL> textureUploadQueue = new ConcurrentQueue<TextureGL>();
+        private readonly GLDisposalQueue disposalQueue = new GLDisposalQueue();
+
+        private readonly Scheduler resetScheduler = new Scheduler(() => ThreadSafety.IsDrawThread, new StopwatchClock(true)); // force no thread set until we are actually on the draw thread.
+
+        private readonly Stack<IVertexBatch<TexturedVertex2D>> quadBatches = new Stack<IVertexBatch<TexturedVertex2D>>();
+        private readonly List<IVertexBuffer> vertexBuffersInUse = new List<IVertexBuffer>();
+        private readonly List<IVertexBatch> batchResetList = new List<IVertexBatch>();
+        private readonly Stack<RectangleI> viewportStack = new Stack<RectangleI>();
+        private readonly Stack<RectangleF> orthoStack = new Stack<RectangleF>();
+        private readonly Stack<MaskingInfo> maskingStack = new Stack<MaskingInfo>();
+        private readonly Stack<RectangleI> scissorRectStack = new Stack<RectangleI>();
+        private readonly Stack<DepthInfo> depthStack = new Stack<DepthInfo>();
+        private readonly Stack<Vector2I> scissorOffsetStack = new Stack<Vector2I>();
+        private readonly Stack<Shader> shaderStack = new Stack<Shader>();
+        private readonly Stack<bool> scissorStateStack = new Stack<bool>();
+        private readonly Stack<int> frameBufferStack = new Stack<int>();
+        private readonly bool[] lastBoundTextureIsAtlas = new bool[16];
+        private readonly int[] lastBoundBuffers = new int[2];
+        private readonly int[] lastBoundTexture = new int[16];
+
+        private BlendingParameters lastBlendingParameters;
+        private IVertexBatch? lastActiveBatch;
+        private TextureUnit lastActiveTextureUnit;
+        private MaskingInfo currentMaskingInfo;
+        private ClearInfo currentClearInfo;
+        private Shader? currentShader;
+        private bool? lastBlendingEnabledState;
+        private bool currentScissorState;
+        private bool isInitialised;
+        private IVertexBatch<TexturedVertex2D>? defaultQuadBatch;
+
+        void IRenderer.Initialise()
+        {
+            string version = GL.GetString(StringName.Version);
+            IsEmbedded = version.Contains("OpenGL ES"); // As defined by https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glGetString.xml
+
+            MaxTextureSize = GL.GetInteger(GetPName.MaxTextureSize);
+            MaxRenderBufferSize = GL.GetInteger(GetPName.MaxRenderbufferSize);
+
+            GL.Disable(EnableCap.StencilTest);
+            GL.Enable(EnableCap.Blend);
+
+            defaultQuadBatch = CreateQuadBatch<TexturedVertex2D>(100, 1000);
+
+            resetScheduler.AddDelayed(checkPendingDisposals, 0, true);
+            isInitialised = true;
+        }
+
+        private void checkPendingDisposals()
+        {
+            disposalQueue.CheckPendingDisposals();
+        }
+
+        void IRenderer.BeginFrame(Vector2 windowSize)
+        {
+            Debug.Assert(defaultQuadBatch != null);
+
+            ResetId++;
+
+            resetScheduler.Update();
+
+            statExpensiveOperationsQueued.Value = expensiveOperationQueue.Count;
+
+            while (expensiveOperationQueue.TryDequeue(out ScheduledDelegate? operation))
+            {
+                if (operation.State == ScheduledDelegate.RunState.Waiting)
+                {
+                    operation.RunTask();
+                    break;
+                }
+            }
+
+            lastActiveBatch = null;
+            lastBlendingParameters = new BlendingParameters();
+            lastBlendingEnabledState = null;
+
+            foreach (var b in batchResetList)
+                b.ResetCounters();
+            batchResetList.Clear();
+
+            currentShader?.Unbind();
+            currentShader = null;
+            shaderStack.Clear();
+            GL.UseProgram(0);
+
+            viewportStack.Clear();
+            orthoStack.Clear();
+            maskingStack.Clear();
+            scissorRectStack.Clear();
+            frameBufferStack.Clear();
+            depthStack.Clear();
+            scissorStateStack.Clear();
+            scissorOffsetStack.Clear();
+
+            quadBatches.Clear();
+            quadBatches.Push(defaultQuadBatch);
+
+            BindFrameBuffer(BackbufferFramebuffer);
+
+            Scissor = RectangleI.Empty;
+            ScissorOffset = Vector2I.Zero;
+            Viewport = RectangleI.Empty;
+            Ortho = RectangleF.Empty;
+
+            PushScissorState(true);
+            PushViewport(new RectangleI(0, 0, (int)windowSize.X, (int)windowSize.Y));
+            PushScissor(new RectangleI(0, 0, (int)windowSize.X, (int)windowSize.Y));
+            PushScissorOffset(Vector2I.Zero);
+            PushMaskingInfo(new MaskingInfo
+            {
+                ScreenSpaceAABB = new RectangleI(0, 0, (int)windowSize.X, (int)windowSize.Y),
+                MaskingRect = new RectangleF(0, 0, windowSize.X, windowSize.Y),
+                ToMaskingSpace = Matrix3.Identity,
+                BlendRange = 1,
+                AlphaExponent = 1,
+                CornerExponent = 2.5f,
+            }, true);
+
+            PushDepthInfo(DepthInfo.Default);
+            Clear(new ClearInfo(Color4.Black));
+
+            freeUnusedVertexBuffers();
+
+            statTextureUploadsQueued.Value = textureUploadQueue.Count;
+            statTextureUploadsDequeued.Value = 0;
+            statTextureUploadsPerformed.Value = 0;
+
+            // increase the number of items processed with the queue length to ensure it doesn't get out of hand.
+            int targetUploads = Math.Clamp(textureUploadQueue.Count / 2, 1, MaxTexturesUploadedPerFrame);
+            int uploads = 0;
+            int uploadedPixels = 0;
+
+            // continue attempting to upload textures until enough uploads have been performed.
+            while (textureUploadQueue.TryDequeue(out TextureGL? texture))
+            {
+                statTextureUploadsDequeued.Value++;
+
+                texture.IsQueuedForUpload = false;
+
+                if (!texture.Upload())
+                    continue;
+
+                statTextureUploadsPerformed.Value++;
+
+                if (++uploads >= targetUploads)
+                    break;
+
+                if ((uploadedPixels += texture.Width * texture.Height) > MaxPixelsUploadedPerFrame)
+                    break;
+            }
+
+            lastBoundTexture.AsSpan().Clear();
+            lastBoundTextureIsAtlas.AsSpan().Clear();
+            lastBoundBuffers.AsSpan().Clear();
+        }
+
+        void IRenderer.FinishFrame()
+        {
+            flushCurrentBatch();
+        }
+
+        private void freeUnusedVertexBuffers()
+        {
+            if (ResetId % vbo_free_check_interval != 0)
+                return;
+
+            foreach (var buf in vertexBuffersInUse)
+            {
+                if (buf.InUse && ResetId - buf.LastUseResetId > vbo_free_check_interval)
+                    buf.Free();
+            }
+
+            vertexBuffersInUse.RemoveAll(b => !b.InUse);
+        }
+
+        public void Clear(ClearInfo clearInfo)
+        {
+            PushDepthInfo(new DepthInfo(writeDepth: true));
+            PushScissorState(false);
+            if (clearInfo.Colour != currentClearInfo.Colour)
+                GL.ClearColor(clearInfo.Colour);
+
+            if (clearInfo.Depth != currentClearInfo.Depth)
+            {
+                if (IsEmbedded)
+                {
+                    // GL ES only supports glClearDepthf
+                    // See: https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glClearDepthf.xhtml
+                    GL.ClearDepth((float)clearInfo.Depth);
+                }
+                else
+                {
+                    // Older desktop platforms don't support glClearDepthf, so standard GL's double version is used instead
+                    // See: https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearDepth.xhtml
+                    osuTK.Graphics.OpenGL.GL.ClearDepth(clearInfo.Depth);
+                }
+            }
+
+            if (clearInfo.Stencil != currentClearInfo.Stencil)
+                GL.ClearStencil(clearInfo.Stencil);
+
+            GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit | ClearBufferMask.StencilBufferBit);
+
+            currentClearInfo = clearInfo;
+
+            PopScissorState();
+            PopDepthInfo();
+        }
+
+        public void PushScissorState(bool enabled)
+        {
+            scissorStateStack.Push(enabled);
+            setScissorState(enabled);
+        }
+
+        public void PopScissorState()
+        {
+            Trace.Assert(scissorStateStack.Count > 1);
+
+            scissorStateStack.Pop();
+
+            setScissorState(scissorStateStack.Peek());
+        }
+
+        private void setScissorState(bool enabled)
+        {
+            if (enabled == currentScissorState)
+                return;
+
+            currentScissorState = enabled;
+
+            if (enabled)
+                GL.Enable(EnableCap.ScissorTest);
+            else
+                GL.Disable(EnableCap.ScissorTest);
+        }
+
+        public bool BindBuffer(BufferTarget target, int buffer)
+        {
+            int bufferIndex = target - BufferTarget.ArrayBuffer;
+            if (lastBoundBuffers[bufferIndex] == buffer)
+                return false;
+
+            lastBoundBuffers[bufferIndex] = buffer;
+            GL.BindBuffer(target, buffer);
+
+            FrameStatistics.Increment(StatisticsCounterType.VBufBinds);
+
+            return true;
+        }
+
+        public bool BindTexture(Texture texture, TextureUnit unit = TextureUnit.Texture0, WrapMode wrapModeS = WrapMode.None, WrapMode wrapModeT = WrapMode.None)
+        {
+            bool didBind = BindTexture(texture.TextureGL.TextureId, unit, wrapModeS, wrapModeT);
+            lastBoundTextureIsAtlas[getTextureUnitId(unit)] = texture.TextureGL is TextureGLAtlas;
+
+            return didBind;
+        }
+
+        public bool BindTexture(int textureId, TextureUnit unit = TextureUnit.Texture0, WrapMode wrapModeS = WrapMode.None, WrapMode wrapModeT = WrapMode.None)
+        {
+            int index = getTextureUnitId(unit);
+
+            if (wrapModeS != CurrentWrapModeS)
+            {
+                // Will flush the current batch internally.
+                GlobalPropertyManager.Set(GlobalProperty.WrapModeS, (int)wrapModeS);
+                CurrentWrapModeS = wrapModeS;
+            }
+
+            if (wrapModeT != CurrentWrapModeT)
+            {
+                // Will flush the current batch internally.
+                GlobalPropertyManager.Set(GlobalProperty.WrapModeT, (int)wrapModeT);
+                CurrentWrapModeT = wrapModeT;
+            }
+
+            if (lastActiveTextureUnit == unit && lastBoundTexture[index] == textureId)
+                return false;
+
+            flushCurrentBatch();
+
+            GL.ActiveTexture(unit);
+            GL.BindTexture(TextureTarget.Texture2D, textureId);
+
+            lastBoundTexture[index] = textureId;
+            lastBoundTextureIsAtlas[getTextureUnitId(unit)] = false;
+            lastActiveTextureUnit = unit;
+
+            FrameStatistics.Increment(StatisticsCounterType.TextureBinds);
+            return true;
+        }
+
+        private int getTextureUnitId(TextureUnit unit) => (int)unit - (int)TextureUnit.Texture0;
+        private bool atlasTextureIsBound(TextureUnit unit) => lastBoundTextureIsAtlas[getTextureUnitId(unit)];
+
+        public void SetBlend(BlendingParameters blendingParameters)
+        {
+            if (lastBlendingParameters == blendingParameters)
+                return;
+
+            flushCurrentBatch();
+
+            if (blendingParameters.IsDisabled)
+            {
+                if (!lastBlendingEnabledState.HasValue || lastBlendingEnabledState.Value)
+                    GL.Disable(EnableCap.Blend);
+
+                lastBlendingEnabledState = false;
+            }
+            else
+            {
+                if (!lastBlendingEnabledState.HasValue || !lastBlendingEnabledState.Value)
+                    GL.Enable(EnableCap.Blend);
+
+                lastBlendingEnabledState = true;
+
+                GL.BlendEquationSeparate(blendingParameters.RGBEquationMode, blendingParameters.AlphaEquationMode);
+                GL.BlendFuncSeparate(blendingParameters.SourceBlendingFactor, blendingParameters.DestinationBlendingFactor,
+                    blendingParameters.SourceAlphaBlendingFactor, blendingParameters.DestinationAlphaBlendingFactor);
+            }
+
+            lastBlendingParameters = blendingParameters;
+        }
+
+        public void PushViewport(RectangleI viewport)
+        {
+            var actualRect = viewport;
+
+            if (actualRect.Width < 0)
+            {
+                actualRect.X += viewport.Width;
+                actualRect.Width = -viewport.Width;
+            }
+
+            if (actualRect.Height < 0)
+            {
+                actualRect.Y += viewport.Height;
+                actualRect.Height = -viewport.Height;
+            }
+
+            PushOrtho(viewport);
+
+            viewportStack.Push(actualRect);
+
+            if (Viewport == actualRect)
+                return;
+
+            Viewport = actualRect;
+
+            GL.Viewport(Viewport.Left, Viewport.Top, Viewport.Width, Viewport.Height);
+        }
+
+        public void PopViewport()
+        {
+            Trace.Assert(viewportStack.Count > 1);
+
+            PopOrtho();
+
+            viewportStack.Pop();
+            RectangleI actualRect = viewportStack.Peek();
+
+            if (Viewport == actualRect)
+                return;
+
+            Viewport = actualRect;
+
+            GL.Viewport(Viewport.Left, Viewport.Top, Viewport.Width, Viewport.Height);
+        }
+
+        public void PushScissor(RectangleI scissor)
+        {
+            flushCurrentBatch();
+
+            scissorRectStack.Push(scissor);
+            if (Scissor == scissor)
+                return;
+
+            Scissor = scissor;
+            setScissor(scissor);
+        }
+
+        public void PopScissor()
+        {
+            Trace.Assert(scissorRectStack.Count > 1);
+
+            flushCurrentBatch();
+
+            scissorRectStack.Pop();
+            RectangleI scissor = scissorRectStack.Peek();
+
+            if (Scissor == scissor)
+                return;
+
+            Scissor = scissor;
+            setScissor(scissor);
+        }
+
+        private void setScissor(RectangleI scissor)
+        {
+            if (scissor.Width < 0)
+            {
+                scissor.X += scissor.Width;
+                scissor.Width = -scissor.Width;
+            }
+
+            if (scissor.Height < 0)
+            {
+                scissor.Y += scissor.Height;
+                scissor.Height = -scissor.Height;
+            }
+
+            GL.Scissor(scissor.X, Viewport.Height - scissor.Bottom, scissor.Width, scissor.Height);
+        }
+
+        public void PushScissorOffset(Vector2I offset)
+        {
+            flushCurrentBatch();
+
+            scissorOffsetStack.Push(offset);
+            if (ScissorOffset == offset)
+                return;
+
+            ScissorOffset = offset;
+        }
+
+        public void PopScissorOffset()
+        {
+            Trace.Assert(scissorOffsetStack.Count > 1);
+
+            flushCurrentBatch();
+
+            scissorOffsetStack.Pop();
+            Vector2I offset = scissorOffsetStack.Peek();
+
+            if (ScissorOffset == offset)
+                return;
+
+            ScissorOffset = offset;
+        }
+
+        public void PushOrtho(RectangleF ortho)
+        {
+            flushCurrentBatch();
+
+            orthoStack.Push(ortho);
+            if (Ortho == ortho)
+                return;
+
+            Ortho = ortho;
+
+            ProjectionMatrix = Matrix4.CreateOrthographicOffCenter(Ortho.Left, Ortho.Right, Ortho.Bottom, Ortho.Top, -1, 1);
+            GlobalPropertyManager.Set(GlobalProperty.ProjMatrix, ProjectionMatrix);
+        }
+
+        public void PopOrtho()
+        {
+            Trace.Assert(orthoStack.Count > 1);
+
+            flushCurrentBatch();
+
+            orthoStack.Pop();
+            RectangleF actualRect = orthoStack.Peek();
+
+            if (Ortho == actualRect)
+                return;
+
+            Ortho = actualRect;
+
+            ProjectionMatrix = Matrix4.CreateOrthographicOffCenter(Ortho.Left, Ortho.Right, Ortho.Bottom, Ortho.Top, -1, 1);
+            GlobalPropertyManager.Set(GlobalProperty.ProjMatrix, ProjectionMatrix);
+        }
+
+        public void PushMaskingInfo(in MaskingInfo maskingInfo, bool overwritePreviousScissor = false)
+        {
+            maskingStack.Push(maskingInfo);
+            if (CurrentMaskingInfo == maskingInfo)
+                return;
+
+            currentMaskingInfo = maskingInfo;
+            setMaskingInfo(CurrentMaskingInfo, true, overwritePreviousScissor);
+        }
+
+        public void PopMaskingInfo()
+        {
+            Trace.Assert(maskingStack.Count > 1);
+
+            maskingStack.Pop();
+            MaskingInfo maskingInfo = maskingStack.Peek();
+
+            if (CurrentMaskingInfo == maskingInfo)
+                return;
+
+            currentMaskingInfo = maskingInfo;
+            setMaskingInfo(CurrentMaskingInfo, false, true);
+        }
+
+        private void setMaskingInfo(MaskingInfo maskingInfo, bool isPushing, bool overwritePreviousScissor)
+        {
+            flushCurrentBatch();
+
+            GlobalPropertyManager.Set(GlobalProperty.MaskingRect, new Vector4(
+                maskingInfo.MaskingRect.Left,
+                maskingInfo.MaskingRect.Top,
+                maskingInfo.MaskingRect.Right,
+                maskingInfo.MaskingRect.Bottom));
+
+            GlobalPropertyManager.Set(GlobalProperty.ToMaskingSpace, maskingInfo.ToMaskingSpace);
+
+            GlobalPropertyManager.Set(GlobalProperty.CornerRadius, maskingInfo.CornerRadius);
+            GlobalPropertyManager.Set(GlobalProperty.CornerExponent, maskingInfo.CornerExponent);
+
+            GlobalPropertyManager.Set(GlobalProperty.BorderThickness, maskingInfo.BorderThickness / maskingInfo.BlendRange);
+
+            if (maskingInfo.BorderThickness > 0)
+            {
+                GlobalPropertyManager.Set(GlobalProperty.BorderColour, new Matrix4(
+                    // TopLeft
+                    maskingInfo.BorderColour.TopLeft.Linear.R,
+                    maskingInfo.BorderColour.TopLeft.Linear.G,
+                    maskingInfo.BorderColour.TopLeft.Linear.B,
+                    maskingInfo.BorderColour.TopLeft.Linear.A,
+                    // BottomLeft
+                    maskingInfo.BorderColour.BottomLeft.Linear.R,
+                    maskingInfo.BorderColour.BottomLeft.Linear.G,
+                    maskingInfo.BorderColour.BottomLeft.Linear.B,
+                    maskingInfo.BorderColour.BottomLeft.Linear.A,
+                    // TopRight
+                    maskingInfo.BorderColour.TopRight.Linear.R,
+                    maskingInfo.BorderColour.TopRight.Linear.G,
+                    maskingInfo.BorderColour.TopRight.Linear.B,
+                    maskingInfo.BorderColour.TopRight.Linear.A,
+                    // BottomRight
+                    maskingInfo.BorderColour.BottomRight.Linear.R,
+                    maskingInfo.BorderColour.BottomRight.Linear.G,
+                    maskingInfo.BorderColour.BottomRight.Linear.B,
+                    maskingInfo.BorderColour.BottomRight.Linear.A));
+            }
+
+            GlobalPropertyManager.Set(GlobalProperty.MaskingBlendRange, maskingInfo.BlendRange);
+            GlobalPropertyManager.Set(GlobalProperty.AlphaExponent, maskingInfo.AlphaExponent);
+
+            GlobalPropertyManager.Set(GlobalProperty.EdgeOffset, maskingInfo.EdgeOffset);
+
+            GlobalPropertyManager.Set(GlobalProperty.DiscardInner, maskingInfo.Hollow);
+            if (maskingInfo.Hollow)
+                GlobalPropertyManager.Set(GlobalProperty.InnerCornerRadius, maskingInfo.HollowCornerRadius);
+
+            if (isPushing)
+            {
+                // When drawing to a viewport that doesn't match the projection size (e.g. via framebuffers), the resultant image will be scaled
+                Vector2 viewportScale = Vector2.Divide(Viewport.Size, Ortho.Size);
+
+                Vector2 location = (maskingInfo.ScreenSpaceAABB.Location - ScissorOffset) * viewportScale;
+                Vector2 size = maskingInfo.ScreenSpaceAABB.Size * viewportScale;
+
+                RectangleI actualRect = new RectangleI(
+                    (int)Math.Floor(location.X),
+                    (int)Math.Floor(location.Y),
+                    (int)Math.Ceiling(size.X),
+                    (int)Math.Ceiling(size.Y));
+
+                PushScissor(overwritePreviousScissor ? actualRect : RectangleI.Intersect(scissorRectStack.Peek(), actualRect));
+            }
+            else
+                PopScissor();
+        }
+
+        public void PushDepthInfo(DepthInfo depthInfo)
+        {
+            depthStack.Push(depthInfo);
+
+            if (CurrentDepthInfo.Equals(depthInfo))
+                return;
+
+            CurrentDepthInfo = depthInfo;
+            setDepthInfo(CurrentDepthInfo);
+        }
+
+        public void PopDepthInfo()
+        {
+            Trace.Assert(depthStack.Count > 1);
+
+            depthStack.Pop();
+            DepthInfo depthInfo = depthStack.Peek();
+
+            if (CurrentDepthInfo.Equals(depthInfo))
+                return;
+
+            CurrentDepthInfo = depthInfo;
+            setDepthInfo(CurrentDepthInfo);
+        }
+
+        private void setDepthInfo(DepthInfo depthInfo)
+        {
+            flushCurrentBatch();
+
+            if (depthInfo.DepthTest)
+            {
+                GL.Enable(EnableCap.DepthTest);
+                GL.DepthFunc(depthInfo.Function);
+            }
+            else
+                GL.Disable(EnableCap.DepthTest);
+
+            GL.DepthMask(depthInfo.WriteDepth);
+        }
+
+        public void BindFrameBuffer(int frameBuffer)
+        {
+            if (frameBuffer == -1) return;
+
+            bool alreadyBound = frameBufferStack.Count > 0 && frameBufferStack.Peek() == frameBuffer;
+
+            frameBufferStack.Push(frameBuffer);
+
+            if (!alreadyBound)
+            {
+                flushCurrentBatch();
+                GL.BindFramebuffer(FramebufferTarget.Framebuffer, frameBuffer);
+
+                GlobalPropertyManager.Set(GlobalProperty.BackbufferDraw, UsingBackbuffer);
+            }
+
+            GlobalPropertyManager.Set(GlobalProperty.GammaCorrection, UsingBackbuffer);
+        }
+
+        public void UnbindFrameBuffer(int frameBuffer)
+        {
+            if (frameBuffer == -1) return;
+
+            if (frameBufferStack.Peek() != frameBuffer)
+                return;
+
+            frameBufferStack.Pop();
+
+            flushCurrentBatch();
+            GL.BindFramebuffer(FramebufferTarget.Framebuffer, frameBufferStack.Peek());
+
+            GlobalPropertyManager.Set(GlobalProperty.BackbufferDraw, UsingBackbuffer);
+            GlobalPropertyManager.Set(GlobalProperty.GammaCorrection, UsingBackbuffer);
+        }
+
+        public void UseProgram(Shader? shader)
+        {
+            ThreadSafety.EnsureDrawThread();
+
+            if (shader != null)
+                shaderStack.Push(shader);
+            else
+            {
+                shaderStack.Pop();
+
+                //check if the stack is empty, and if so don't restore the previous shader.
+                if (shaderStack.Count == 0)
+                    return;
+            }
+
+            shader ??= shaderStack.Peek();
+
+            if (currentShader == shader)
+                return;
+
+            FrameStatistics.Increment(StatisticsCounterType.ShaderBinds);
+
+            flushCurrentBatch();
+
+            GL.UseProgram(shader);
+            currentShader = shader;
+        }
+
+        public void ScheduleExpensiveOperation(ScheduledDelegate operation)
+        {
+            if (isInitialised)
+                expensiveOperationQueue.Enqueue(operation);
+        }
+
+        public void ScheduleDisposal<T>(Action<T> disposalAction, T target)
+        {
+            if (isInitialised)
+                disposalQueue.ScheduleDisposal(disposalAction, target);
+            else
+                disposalAction.Invoke(target);
+        }
+
+        public IFrameBuffer CreateFrameBuffer(RenderbufferInternalFormat[]? renderBufferFormats = null, All filteringMode = All.Linear)
+            => new FrameBuffer(this, renderBufferFormats, filteringMode);
+
+        public IVertexBatch<TVertex> CreateLinearBatch<TVertex>(int size, int maxBuffers, PrimitiveType primitiveType) where TVertex : struct, IEquatable<TVertex>, IVertex
+            => new LinearBatch<TVertex>(this, size, maxBuffers, primitiveType);
+
+        public IVertexBatch<TVertex> CreateQuadBatch<TVertex>(int size, int maxBuffers) where TVertex : struct, IEquatable<TVertex>, IVertex
+            => new QuadBatch<TVertex>(this, size, maxBuffers);
+
+        void IRenderer.SetUniform<T>(IUniformWithValue<T> uniform)
+        {
+            if (uniform.Owner == currentShader)
+                flushCurrentBatch();
+
+            switch (uniform)
+            {
+                case IUniformWithValue<bool> b:
+                    GL.Uniform1(uniform.Location, b.GetValue() ? 1 : 0);
+                    break;
+
+                case IUniformWithValue<int> i:
+                    GL.Uniform1(uniform.Location, i.GetValue());
+                    break;
+
+                case IUniformWithValue<float> f:
+                    GL.Uniform1(uniform.Location, f.GetValue());
+                    break;
+
+                case IUniformWithValue<Vector2> v2:
+                    GL.Uniform2(uniform.Location, ref v2.GetValueByRef());
+                    break;
+
+                case IUniformWithValue<Vector3> v3:
+                    GL.Uniform3(uniform.Location, ref v3.GetValueByRef());
+                    break;
+
+                case IUniformWithValue<Vector4> v4:
+                    GL.Uniform4(uniform.Location, ref v4.GetValueByRef());
+                    break;
+
+                case IUniformWithValue<Matrix2> m2:
+                    GL.UniformMatrix2(uniform.Location, false, ref m2.GetValueByRef());
+                    break;
+
+                case IUniformWithValue<Matrix3> m3:
+                    GL.UniformMatrix3(uniform.Location, false, ref m3.GetValueByRef());
+                    break;
+
+                case IUniformWithValue<Matrix4> m4:
+                    GL.UniformMatrix4(uniform.Location, false, ref m4.GetValueByRef());
+                    break;
+            }
+        }
+
+        void IRenderer.RegisterVertexBufferUse(IVertexBuffer buffer) => vertexBuffersInUse.Add(buffer);
+
+        void IRenderer.SetActiveBatch(IVertexBatch batch)
+        {
+            if (lastActiveBatch == batch)
+                return;
+
+            batchResetList.Add(batch);
+
+            flushCurrentBatch();
+
+            lastActiveBatch = batch;
+        }
+
+        void IRenderer.SetDrawDepth(float drawDepth) => BackbufferDrawDepth = drawDepth;
+
+        IVertexBatch<TexturedVertex2D> IRenderer.DefaultQuadBatch => quadBatches.Peek();
+
+        void IRenderer.PushQuadBatch(IVertexBatch<TexturedVertex2D> quadBatch) => quadBatches.Push(quadBatch);
+
+        void IRenderer.PopQuadBatch() => quadBatches.Pop();
+
+        /// <summary>
+        /// Deletes a frame buffer.
+        /// </summary>
+        /// <param name="frameBuffer">The frame buffer to delete.</param>
+        public void DeleteFrameBuffer(int frameBuffer)
+        {
+            if (frameBuffer == -1) return;
+
+            while (frameBufferStack.Peek() == frameBuffer)
+                UnbindFrameBuffer(frameBuffer);
+
+            ScheduleDisposal(GL.DeleteFramebuffer, frameBuffer);
+        }
+
+        private void flushCurrentBatch()
+        {
+            lastActiveBatch?.Draw();
+        }
+    }
+}

--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -19,6 +19,7 @@ using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.EnumExtensions;
+using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
@@ -640,7 +641,7 @@ namespace osu.Framework.Graphics.Video
                     continue;
 
                 if (!availableTextures.TryDequeue(out var tex))
-                    tex = new Texture(new VideoTexture(renderer, frame.Pointer->width, frame.Pointer->height));
+                    tex = new Texture(new VideoTexture((OpenGLRenderer)renderer, frame.Pointer->width, frame.Pointer->height));
 
                 var upload = new VideoTextureUpload(frame);
 

--- a/osu.Framework/Graphics/Video/VideoTexture.cs
+++ b/osu.Framework/Graphics/Video/VideoTexture.cs
@@ -5,9 +5,9 @@
 
 using System;
 using System.Diagnostics;
+using osu.Framework.Graphics.OpenGL;
 using osuTK.Graphics.ES30;
 using osu.Framework.Graphics.OpenGL.Textures;
-using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Platform;
 
@@ -22,7 +22,7 @@ namespace osu.Framework.Graphics.Video
         /// </summary>
         public bool UploadComplete { get; private set; }
 
-        public VideoTexture(IRenderer renderer, int width, int height, WrapMode wrapModeS = WrapMode.None, WrapMode wrapModeT = WrapMode.None)
+        public VideoTexture(OpenGLRenderer renderer, int width, int height, WrapMode wrapModeS = WrapMode.None, WrapMode wrapModeT = WrapMode.None)
             : base(renderer, width, height, true, All.Linear, wrapModeS, wrapModeT)
         {
         }

--- a/osu.Framework/Graphics/Visualisation/TextureVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/TextureVisualiser.cs
@@ -261,7 +261,7 @@ namespace osu.Framework.Graphics.Visualisation
                     }
 
                     // texture
-                    renderer.BindTexture(texture.TextureId);
+                    renderer.BindTexture(new Texture(texture));
                     renderer.DrawQuad(new Texture(texture), shrunkenQuad, Color4.White);
                 }
 

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -36,8 +36,10 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.192" />
-    <PackageReference Include="StbiSharp" Version="1.1.0" />
     <PackageReference Include="ppy.SDL2-CS" Version="1.0.563-alpha" />
+    <PackageReference Include="StbiSharp" Version="1.1.0" />
+    <PackageReference Include="Veldrid" Version="4.9.0-beta1" />
+    <PackageReference Include="Veldrid.SPIRV" Version="1.0.15" />
 
     <!-- Any version ahead of this will cause AOT issues with iOS
          See https://github.com/mono/mono/issues/21188 -->


### PR DESCRIPTION
- [x] Depends on #85 

This follows a simple binding model in which each `VeldridTexture` instantiate their own `ResourceSet` consisting of the underlying Veldrid texture and sampler (using a `VeldridTextureSamplerSet` wrapper), and toss it to `VeldridRenderer` for binding the texture.

May not be the wisest model, but good enough for the time being.